### PR TITLE
Save access in session

### DIFF
--- a/force-app/main/default/lwc/aareg_home/aareg_home.js
+++ b/force-app/main/default/lwc/aareg_home/aareg_home.js
@@ -56,7 +56,8 @@ export default class Aareg_home extends LightningElement {
         this.sortOrganizations();
       });
       // Avoid doing callout on every ConnectedCallback
-      if (sessionStorage.getItem('hasApplicationAccess') === 'true' || sessionStorage.getItem('hasAccess') === 'true') {
+      // Check current user as well to avoid user being logged in on two different users in same session to get access
+      if (sessionStorage.getItem('currentUser') === this.currentUser && (sessionStorage.getItem('hasApplicationAccess') === 'true' || sessionStorage.getItem('hasAccess') === 'true')) {
         if (sessionStorage.getItem('hasApplicationAccess') === 'true') {
           this.hasApplicationAccess = true;
         }
@@ -137,6 +138,7 @@ export default class Aareg_home extends LightningElement {
           } else if (privilege.ServiceCode === '5441' && privilege.ServiceEditionCode === '2') {
             this.hasAccess = true;
           }
+          sessionStorage.setItem('currentUser', this.currentUser);
           sessionStorage.setItem('hasAccess', JSON.stringify(this.hasAccess));
           sessionStorage.setItem('hasApplicationAccess', JSON.stringify(this.hasApplicationAccess));
         });

--- a/force-app/main/default/lwc/aareg_home/aareg_home.js
+++ b/force-app/main/default/lwc/aareg_home/aareg_home.js
@@ -78,6 +78,7 @@ export default class Aareg_home extends LightningElement {
   async handleOrganizationChange(event) {
     this.isLoaded = false;
     this.hasAccess = false;
+    this.hasApplicationAccess = false;
     this.lastUsedOrganization = event.target.value;
     try {
       await updateLastUsedOrganization({ organizationNumber: this.lastUsedOrganization, userId: this.currentUser }).then(() => {
@@ -142,6 +143,7 @@ export default class Aareg_home extends LightningElement {
         });
       } else {
         this.hasAccess = false;
+        this.hasApplicationAccess = false;
         sessionStorage.setItem('hasAccess', JSON.stringify(false));
         sessionStorage.setItem('hasApplicationAccess', JSON.stringify(false));
         throw `Failed to get rights to application ${result.errorMessage}`;

--- a/force-app/main/default/lwc/aareg_home/aareg_home.js
+++ b/force-app/main/default/lwc/aareg_home/aareg_home.js
@@ -55,7 +55,7 @@ export default class Aareg_home extends LightningElement {
         this.lastUsedOrganization = result;
         this.sortOrganizations();
       });
-      // Only do callout when doing it for the first time or if no rights saved in session
+      // Avoid doing callout on every ConnectedCallback
       if (sessionStorage.getItem('hasApplicationAccess') === 'true' || sessionStorage.getItem('hasAccess') === 'true') {
         if (sessionStorage.getItem('hasApplicationAccess') === 'true') {
           this.hasApplicationAccess = true;

--- a/force-app/main/default/lwc/aareg_home/aareg_home.js
+++ b/force-app/main/default/lwc/aareg_home/aareg_home.js
@@ -134,7 +134,6 @@ export default class Aareg_home extends LightningElement {
           if (privilege.ServiceCode === '5719') {
             this.hasAccess = true;
             this.hasApplicationAccess = true;
-            
           } else if (privilege.ServiceCode === '5441' && privilege.ServiceEditionCode === '2') {
             this.hasAccess = true;
           }

--- a/force-app/main/default/lwc/aareg_home/aareg_home.js
+++ b/force-app/main/default/lwc/aareg_home/aareg_home.js
@@ -55,6 +55,16 @@ export default class Aareg_home extends LightningElement {
         this.lastUsedOrganization = result;
         this.sortOrganizations();
       });
+      // Only do callout when doing it for the first time or if no rights saved in session
+      if (sessionStorage.getItem('hasApplicationAccess') === 'true' || sessionStorage.getItem('hasAccess') === 'true') {
+        if (sessionStorage.getItem('hasApplicationAccess') === 'true') {
+          this.hasApplicationAccess = true;
+        }
+        if (sessionStorage.getItem('hasAccess') === 'true') {
+          this.hasAccess = true;
+        }
+        return;
+      }
 
       await this.checkAccessToApplication('5719');
       if (this.hasApplicationAccess === false) await this.checkAccessToApplication('5441');
@@ -123,12 +133,17 @@ export default class Aareg_home extends LightningElement {
           if (privilege.ServiceCode === '5719') {
             this.hasAccess = true;
             this.hasApplicationAccess = true;
+            
           } else if (privilege.ServiceCode === '5441' && privilege.ServiceEditionCode === '2') {
             this.hasAccess = true;
           }
+          sessionStorage.setItem('hasAccess', JSON.stringify(this.hasAccess));
+          sessionStorage.setItem('hasApplicationAccess', JSON.stringify(this.hasApplicationAccess));
         });
       } else {
         this.hasAccess = false;
+        sessionStorage.setItem('hasAccess', JSON.stringify(false));
+        sessionStorage.setItem('hasApplicationAccess', JSON.stringify(false));
         throw `Failed to get rights to application ${result.errorMessage}`;
       }
     });


### PR DESCRIPTION
Eneste gangene man kan få en "No access" nå er om at request gir tilbake null, som kan skje ved login eller når man bytter org en sjelden gang. Christian Breternitz jobber med å fikse JWTTokenExchange med Maskinporten. Ideelt sett bør man benytte seg av expiry verdien man får igjen slik at man ikke spør etter ny token ved hver request, og det skal han implementere, som forhåpentligvis fikser access_token=null feilen.